### PR TITLE
Allow filename to have trailing spaces

### DIFF
--- a/lib/OLE/Storage_Lite.pm
+++ b/lib/OLE/Storage_Lite.pm
@@ -917,7 +917,7 @@ sub _initParse($) {
   #3. $sFile is a simple filename string
   elsif(!ref($sFile)) {
     $oIo = new IO::File;
-    $oIo->open("<$sFile") || return undef;
+    $oIo->open($sFile, "r") || return undef;
     binmode($oIo);
   }
   #4 Assume that if $sFile is a ref then it is a valid filehandle


### PR DESCRIPTION
This changes the call to open the file to pass the open mode as a separate parameter, so the parsing of the filename will not swallow the leading space.

See https://github.com/mvz/email-outlook-message-perl/issues/10 for context.