### PR TITLE
95+% perf improvement

### DIFF
--- a/lib/OLE/Storage_Lite.pm
+++ b/lib/OLE/Storage_Lite.pm
@@ -826,7 +826,9 @@ package OLE::Storage_Lite;
 require Exporter;
 
 use strict;
+use Carp;
 use IO::File;
+use List::Util qw(first);
 use Time::Local 'timegm';
 
 use vars qw($VERSION @ISA @EXPORT);
@@ -838,12 +840,17 @@ sub _getPpsTree($$$;$);
 # Const for OLE::Storage_Lite
 #------------------------------------------------------------------------------
 #0. Constants
-sub PpsType_Root {5};
-sub PpsType_Dir  {1};
-sub PpsType_File {2};
-sub DataSizeSmall{0x1000};
-sub LongIntSize  {4};
-sub PpsSize      {0x80};
+use constant {
+  PpsType_Root   => 5,
+  PpsType_Dir    => 1,
+  PpsType_File   => 2,
+  DataSizeSmall  => 0x1000,
+  LongIntSize    => 4,
+  PpsSize        => 0x80,
+  # 0xFFFFFFFC : BDList, 0xFFFFFFFD : BBD,
+  # 0xFFFFFFFE: End of Chain 0xFFFFFFFF : unused
+  NormalBlockEnd => 0xFFFFFFFC,
+};
 #------------------------------------------------------------------------------
 # new OLE::Storage_Lite
 #------------------------------------------------------------------------------
@@ -917,7 +924,7 @@ sub _initParse($) {
   #3. $sFile is a simple filename string
   elsif(!ref($sFile)) {
     $oIo = new IO::File;
-    $oIo->open($sFile, "r") || return undef;
+    $oIo->open("<$sFile") || return undef;
     binmode($oIo);
   }
   #4 Assume that if $sFile is a ref then it is a valid filehandle
@@ -934,12 +941,12 @@ sub _initParse($) {
 sub _getPpsTree($$$;$) {
   my($iNo, $rhInfo, $bData, $raDone) = @_;
   if(defined($raDone)) {
-    return () if(grep {$_ ==$iNo} @$raDone);
+    return () if(exists($raDone->{$iNo}));
   }
   else {
-    $raDone=[];
+    $raDone={};
   }
-  push @$raDone, $iNo;
+  $raDone->{$iNo} = undef;
 
   my $iRootBlock = $rhInfo->{_ROOT_START} ;
 #1. Get Information about itself
@@ -970,16 +977,16 @@ sub _getPpsSearch($$$$$;$) {
   my @aRes;
 #1. Check it self
   if(defined($raDone)) {
-    return () if(grep {$_==$iNo} @$raDone);
+    return () if(exists($raDone->{$iNo}));
   }
   else {
-    $raDone=[];
+    $raDone={};
   }
-  push @$raDone, $iNo;
+  $raDone->{$iNo} = undef;
   my $oPps = _getNthPps($iNo, $rhInfo, undef);
-#  if(grep($_ eq $oPps->{Name}, @$raName)) {
-  if(($iCase && (grep(/^\Q$oPps->{Name}\E$/i, @$raName))) ||
-     (grep($_ eq $oPps->{Name}, @$raName))) {
+#  if(defined(first {$_ eq $oPps->{Name}, @$raName})) {
+  if(($iCase && (defined(first {$_ =~/^\Q$oPps->{Name}\E$/i, @$raName}))) ||
+     (defined(first {$_ eq $oPps->{Name}, @$raName}))) {
     $oPps = _getNthPps($iNo, $rhInfo, $bData) if ($bData);
     @aRes = ($oPps);
   }
@@ -1050,6 +1057,32 @@ sub _getHeaderInfo($){
   my $oRoot = _getNthPps(0, $rhInfo, undef);
   $rhInfo->{_SB_START} = $oRoot->{StartBlock};
   $rhInfo->{_SB_SIZE}  = $oRoot->{Size};
+# cache lookaheads for huge performance improvement in some cases
+  my $iNextCount = keys(%{$rhInfo->{_BBD_INFO}});
+  my $iBlockNo = $rhInfo->{_ROOT_START};
+  my $iBigBlkSize=$rhInfo->{_BIG_BLOCK_SIZE};
+  $rhInfo->{_BBD_ROOT_START}= [$iBlockNo];
+  for(1..$iNextCount) {
+    $iBlockNo = $rhInfo->{_BBD_INFO}->{$iBlockNo} // $iBlockNo+1;
+    last unless $iBlockNo < OLE::Storage_Lite::NormalBlockEnd();
+    $rhInfo->{_BBD_ROOT_START}->[$_] = $iBlockNo;
+  }
+  $iBlockNo = $rhInfo->{_SB_START};
+  $rhInfo->{_BBD_SB_START}= [($iBlockNo+1)*$iBigBlkSize];
+  for(1..$iNextCount) {
+    $iBlockNo = $rhInfo->{_BBD_INFO}->{$iBlockNo} // $iBlockNo+1;
+    last unless $iBlockNo < OLE::Storage_Lite::NormalBlockEnd();
+    $rhInfo->{_BBD_SB_START}->[$_] = ($iBlockNo+1)*$iBigBlkSize;
+  }
+  $iBlockNo = $rhInfo->{_SBD_START};
+  $rhInfo->{_BBD_SBD_START}= [($iBlockNo+1)*$iBigBlkSize];
+  for(1..$iNextCount) {
+    $iBlockNo = $rhInfo->{_BBD_INFO}->{$iBlockNo} // $iBlockNo+1;
+    last unless $iBlockNo < OLE::Storage_Lite::NormalBlockEnd();
+    $rhInfo->{_BBD_SBD_START}->[$_] = ($iBlockNo+1)*$iBigBlkSize;
+  }
+  my @aKeys= sort({$a<=>$b} keys(%{$rhInfo->{_BBD_INFO}}));
+  $rhInfo->{_BBD_INFO_SORTED}= \@aKeys;
   return $rhInfo;
 }
 #------------------------------------------------------------------------------
@@ -1070,10 +1103,11 @@ sub _getBbdInfo($) {
   my($rhInfo) =@_;
   my @aBdList = ();
   my $iBdbCnt = $rhInfo->{_BDB_COUNT};
+  my $iBigBlkSize = $rhInfo->{_BIG_BLOCK_SIZE};
   my $iGetCnt;
   my $sWk;
-  my $i1stCnt = int(($rhInfo->{_BIG_BLOCK_SIZE} - 0x4C) / OLE::Storage_Lite::LongIntSize());
-  my $iBdlCnt = int($rhInfo->{_BIG_BLOCK_SIZE} / OLE::Storage_Lite::LongIntSize()) - 1;
+  my $i1stCnt = int(($iBigBlkSize - 0x4C) / OLE::Storage_Lite::LongIntSize());
+  my $iBdlCnt = int($iBigBlkSize / OLE::Storage_Lite::LongIntSize()) - 1;
 
 #1. 1st BDlist
   $rhInfo->{_FILEH_}->seek(0x4C, 0);
@@ -1083,8 +1117,8 @@ sub _getBbdInfo($) {
   $iBdbCnt -= $iGetCnt;
 #2. Extra BDList
   my $iBlock = $rhInfo->{_EXTRA_BBD_START};
-  while(($iBdbCnt> 0) && _isNormalBlock($iBlock)){
-    _setFilePos($iBlock, 0, $rhInfo);
+  while(($iBdbCnt> 0) && $iBlock < OLE::Storage_Lite::NormalBlockEnd()){
+    $rhInfo->{_FILEH_}->seek(($iBlock+1)*$iBigBlkSize, 0);
     $iGetCnt= ($iBdbCnt < $iBdlCnt)? $iBdbCnt: $iBdlCnt;
     $rhInfo->{_FILEH_}->read($sWk, OLE::Storage_Lite::LongIntSize()*$iGetCnt);
     push @aBdList, unpack("V$iGetCnt", $sWk);
@@ -1098,10 +1132,10 @@ sub _getBbdInfo($) {
   my $iBlkNo = 0;
   my $iBdL;
   my $i;
-  my $iBdCnt = int($rhInfo->{_BIG_BLOCK_SIZE} / OLE::Storage_Lite::LongIntSize());
+  my $iBdCnt = int($iBigBlkSize / OLE::Storage_Lite::LongIntSize());
   foreach $iBdL (@aBdList) {
-    _setFilePos($iBdL, 0, $rhInfo);
-    $rhInfo->{_FILEH_}->read($sWk, $rhInfo->{_BIG_BLOCK_SIZE});
+    $rhInfo->{_FILEH_}->seek(($iBdL+1)*$iBigBlkSize, 0);
+    $rhInfo->{_FILEH_}->read($sWk, $iBigBlkSize);
     @aWk = unpack("V$iBdCnt", $sWk);
     for($i=0;$i<$iBdCnt;$i++, $iBlkNo++) {
        if($aWk[$i] != ($iBlkNo+1)){
@@ -1116,7 +1150,6 @@ sub _getBbdInfo($) {
 #------------------------------------------------------------------------------
 sub _getNthPps($$$){
   my($iPos, $rhInfo, $bData) = @_;
-  my($iPpsStart) = ($rhInfo->{_ROOT_START});
   my($iPpsBlock, $iPpsPos);
   my $sWk;
   my $iBlock;
@@ -1125,19 +1158,18 @@ sub _getNthPps($$$){
   $iPpsBlock = int($iPos / $iBaseCnt);
   $iPpsPos   = $iPos % $iBaseCnt;
 
-  $iBlock = _getNthBlockNo($iPpsStart, $iPpsBlock, $rhInfo);
+  $iBlock = $rhInfo->{_BBD_ROOT_START}->[$iPpsBlock] //
+    _getNthBlockNo($rhInfo->{_ROOT_START}, $iPpsBlock, $rhInfo);
   return undef unless(defined($iBlock));
 
-  _setFilePos($iBlock, OLE::Storage_Lite::PpsSize()*$iPpsPos, $rhInfo);
+  $rhInfo->{_FILEH_}->seek(($iBlock+1)*$rhInfo->{_BIG_BLOCK_SIZE}+
+    (OLE::Storage_Lite::PpsSize()*$iPpsPos), 0);
   $rhInfo->{_FILEH_}->read($sWk, OLE::Storage_Lite::PpsSize());
   return undef unless($sWk);
-  my $iNmSize = unpack("v", substr($sWk, 0x40, 2));
+  my ($iNmSize, $iType, undef, $lPpsPrev, $lPpsNext, $lDirPps) =
+    unpack("vCCVVV", substr($sWk, 0x40, 2+2+3*OLE::Storage_Lite::LongIntSize()));
   $iNmSize = ($iNmSize > 2)? $iNmSize - 2 : $iNmSize;
   my $sNm= substr($sWk, 0, $iNmSize);
-  my $iType = unpack("C", substr($sWk, 0x42, 2));
-  my $lPpsPrev = unpack("V", substr($sWk, 0x44, OLE::Storage_Lite::LongIntSize()));
-  my $lPpsNext = unpack("V", substr($sWk, 0x48, OLE::Storage_Lite::LongIntSize()));
-  my $lDirPps  = unpack("V", substr($sWk, 0x4C, OLE::Storage_Lite::LongIntSize()));
   my @raTime1st =
         (($iType == OLE::Storage_Lite::PpsType_Root()) or ($iType == OLE::Storage_Lite::PpsType_Dir()))?
             OLEDate2Local(substr($sWk, 0x64, 8)) : undef ,
@@ -1158,25 +1190,16 @@ sub _getNthPps($$$){
   }
 }
 #------------------------------------------------------------------------------
-# _setFilePos (OLE::Storage_Lite)
-#------------------------------------------------------------------------------
-sub _setFilePos($$$){
-  my($iBlock, $iPos, $rhInfo) = @_;
-  $rhInfo->{_FILEH_}->seek(($iBlock+1)*$rhInfo->{_BIG_BLOCK_SIZE}+$iPos, 0);
-}
-#------------------------------------------------------------------------------
 # _getNthBlockNo (OLE::Storage_Lite)
 #------------------------------------------------------------------------------
 sub _getNthBlockNo($$$){
-  my($iStBlock, $iNth, $rhInfo) = @_;
-  my $iSv;
-  my $iNext = $iStBlock;
-  for(my $i =0; $i<$iNth; $i++) {
-    $iSv = $iNext;
-    $iNext = _getNextBlockNo($iSv, $rhInfo);
-    return undef unless _isNormalBlock($iNext);
+  my($iBlockNo, $iNth, $rhInfo) = @_;
+  my $rhBbdInfo = $rhInfo->{_BBD_INFO};
+  for(1..$iNth) {
+    $iBlockNo = $rhBbdInfo->{$iBlockNo} // $iBlockNo+1;
+    return undef unless $iBlockNo < OLE::Storage_Lite::NormalBlockEnd();
   }
-  return $iNext;
+  return $iBlockNo;
 }
 #------------------------------------------------------------------------------
 # _getData (OLE::Storage_Lite)
@@ -1207,18 +1230,31 @@ sub _getBigData($$$)
   my($iBlock, $iSize, $rhInfo) = @_;
   my($iRest, $sWk, $sRes);
 
-  return '' unless(_isNormalBlock($iBlock));
+  return '' unless($iBlock < OLE::Storage_Lite::NormalBlockEnd());
   $iRest = $iSize;
   my($i, $iGetSize, $iNext);
   $sRes = '';
-  my @aKeys= sort({$a<=>$b} keys(%{$rhInfo->{_BBD_INFO}}));
+  my $aKeys= $rhInfo->{_BBD_INFO_SORTED};
 
   while ($iRest > 0) {
-    my @aRes = grep($_ >= $iBlock, @aKeys);
-    my $iNKey = $aRes[0];
+    # lower_bound binary search
+    my $iCount = @$aKeys;
+    my $iFirst = 0;
+    while ($iCount > 0) {
+      my $iStep = $iCount >> 1;
+      my $iIndex = $iFirst + $iStep;
+      if ($$aKeys[$iIndex] < $iBlock) {
+        $iFirst = ++$iIndex;
+        $iCount -= $iStep + 1;
+      } else {
+        $iCount = $iStep;
+      }
+    }
+    my $iNKey = $$aKeys[$iFirst];
     $i = $iNKey - $iBlock;
+    croak "Invalid block read" if ($i < 0);
     $iNext = $rhInfo->{_BBD_INFO}{$iNKey};
-    _setFilePos($iBlock, 0, $rhInfo);
+    $rhInfo->{_FILEH_}->seek(($iBlock+1)*$rhInfo->{_BIG_BLOCK_SIZE}, 0);
     my $iGetSize = ($rhInfo->{_BIG_BLOCK_SIZE} * ($i+1));
     $iGetSize = $iRest if($iRest < $iGetSize);
     $rhInfo->{_FILEH_}->read( $sWk, $iGetSize);
@@ -1229,88 +1265,58 @@ sub _getBigData($$$)
   return $sRes;
 }
 #------------------------------------------------------------------------------
-# _getNextBlockNo (OLE::Storage_Lite)
-#------------------------------------------------------------------------------
-sub _getNextBlockNo($$){
-  my($iBlockNo, $rhInfo) = @_;
-  my $iRes = $rhInfo->{_BBD_INFO}->{$iBlockNo};
-  return defined($iRes)? $iRes: $iBlockNo+1;
-}
-#------------------------------------------------------------------------------
-# _isNormalBlock (OLE::Storage_Lite)
-# 0xFFFFFFFC : BDList, 0xFFFFFFFD : BBD,
-# 0xFFFFFFFE: End of Chain 0xFFFFFFFF : unused
-#------------------------------------------------------------------------------
-sub _isNormalBlock($){
-  my($iBlock) = @_;
-  return ($iBlock < 0xFFFFFFFC)? 1: undef;
-}
-#------------------------------------------------------------------------------
 # _getSmallData (OLE::Storage_Lite)
 #------------------------------------------------------------------------------
 sub _getSmallData($$$)
 {
   my($iSmBlock, $iSize, $rhInfo) = @_;
   my($sRes, $sWk);
-  my $iRest = $iSize;
+  my($iBigBlkSize, $iSmallBlkSize, $rhFd) =
+    @$rhInfo{qw(_BIG_BLOCK_SIZE _SMALL_BLOCK_SIZE _FILEH_)};
+
   $sRes = '';
-  while ($iRest > 0) {
-    _setFilePosSmall($iSmBlock, $rhInfo);
-    $rhInfo->{_FILEH_}->read($sWk,
-        ($iRest >= $rhInfo->{_SMALL_BLOCK_SIZE})?
-            $rhInfo->{_SMALL_BLOCK_SIZE}: $iRest);
-    $sRes .= $sWk;
-    $iRest -= $rhInfo->{_SMALL_BLOCK_SIZE};
-    $iSmBlock= _getNextSmallBlockNo($iSmBlock, $rhInfo);
+  while ($iSize > 0) {
+    my $iBaseCnt = $iBigBlkSize / $iSmallBlkSize;
+    my $iNth = int($iSmBlock/$iBaseCnt);
+    my $iPos = $iSmBlock % $iBaseCnt;
+    my $iBlk = $rhInfo->{_BBD_SB_START}->[$iNth] //
+      ((_getNthBlockNo($rhInfo->{_SB_START}, $iNth, $rhInfo)+1)*$iBigBlkSize);
+
+    $rhFd->seek($iBlk+($iPos*$iSmallBlkSize), 0);
+    if ($iSize > $iSmallBlkSize) {
+      $rhFd->read($sWk, $iSmallBlkSize);
+      $sRes .= $sWk;
+      $iSize -= $iSmallBlkSize;
+    } else {
+      $rhFd->read($sWk, $iSize);
+      $sRes .= $sWk;
+      last;
+    }
+    # get next small block
+    $iBaseCnt = $iBigBlkSize / OLE::Storage_Lite::LongIntSize();
+    $iNth = int($iSmBlock/$iBaseCnt);
+    $iPos = $iSmBlock % $iBaseCnt;
+    $iBlk = $rhInfo->{_BBD_SBD_START}->[$iNth] //
+      ((_getNthBlockNo($rhInfo->{_SBD_START}, $iNth, $rhInfo)+1)*$iBigBlkSize);
+    $rhFd->seek($iBlk+($iPos*OLE::Storage_Lite::LongIntSize()), 0);
+    $rhFd->read($sWk, OLE::Storage_Lite::LongIntSize());
+    $iSmBlock = unpack("V", $sWk);
   }
   return $sRes;
-}
-#------------------------------------------------------------------------------
-# _setFilePosSmall(OLE::Storage_Lite)
-#------------------------------------------------------------------------------
-sub _setFilePosSmall($$)
-{
-  my($iSmBlock, $rhInfo) = @_;
-  my $iSmStart = $rhInfo->{_SB_START};
-  my $iBaseCnt = $rhInfo->{_BIG_BLOCK_SIZE} / $rhInfo->{_SMALL_BLOCK_SIZE};
-  my $iNth = int($iSmBlock/$iBaseCnt);
-  my $iPos = $iSmBlock % $iBaseCnt;
-
-  my $iBlk = _getNthBlockNo($iSmStart, $iNth, $rhInfo);
-  _setFilePos($iBlk, $iPos * $rhInfo->{_SMALL_BLOCK_SIZE}, $rhInfo);
-}
-#------------------------------------------------------------------------------
-# _getNextSmallBlockNo (OLE::Storage_Lite)
-#------------------------------------------------------------------------------
-sub _getNextSmallBlockNo($$)
-{
-  my($iSmBlock, $rhInfo) = @_;
-  my($sWk);
-
-  my $iBaseCnt = $rhInfo->{_BIG_BLOCK_SIZE} / OLE::Storage_Lite::LongIntSize();
-  my $iNth = int($iSmBlock/$iBaseCnt);
-  my $iPos = $iSmBlock % $iBaseCnt;
-  my $iBlk = _getNthBlockNo($rhInfo->{_SBD_START}, $iNth, $rhInfo);
-  _setFilePos($iBlk, $iPos * OLE::Storage_Lite::LongIntSize(), $rhInfo);
-  $rhInfo->{_FILEH_}->read($sWk, OLE::Storage_Lite::LongIntSize());
-  return unpack("V", $sWk);
-
 }
 #------------------------------------------------------------------------------
 # Asc2Ucs: OLE::Storage_Lite
 #------------------------------------------------------------------------------
 sub Asc2Ucs($)
 {
-  my($sAsc) = @_;
-  return join("\x00", split //, $sAsc) . "\x00";
+  return join("\x00", split //, $_[0]) . "\x00";
 }
 #------------------------------------------------------------------------------
 # Ucs2Asc: OLE::Storage_Lite
 #------------------------------------------------------------------------------
 sub Ucs2Asc($)
 {
-  my($sUcs) = @_;
-  return join('', map(pack('c', $_), unpack('v*', $sUcs)));
+  return pack('c*', unpack('v*', $_[0]));
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This improves performance by 95+ percent on certain complex messages. The sample I have from a customer with large # of destination addresses took 9.5 minutes to parse through Email::Outlook::Message which relies on extracting content with Ole::Storage_lite. After these changes, that times drops to about 3-4 seconds. I'm filing a PR for a few changes in the other module as well
Multiple changes
1) use const to ensure constants are inlined
2) first instead of grep to short-circuit large lists
3) inline functions only called one time that duplicated work
4) highly optimized seek method as it was the worst cpu burn. Break before 2nd offset computation when block has been read completely
5) pre-sort and cache block offsets as the linear scan regressed with #of small data blocks
6) optimize pack+unpack 
7) use hash instead of array to skip work blocks - same linearity issue