### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -1,13 +1,23 @@
---- #YAML:1.0
-name:                OLE-Storage_Lite
-version:             0.18
-abstract:            Read and write OLE storage files.
-license:             ~
-author:              
-    - Kawai Takanori (kwitknr@cpan.org)
-generated_by:        ExtUtils::MakeMaker version 6.44
-distribution_type:   module
-requires:     
+---
+abstract: 'Read and write OLE storage files.'
+author:
+  - 'Kawai Takanori (kwitknr@cpan.org)'
+build_requires:
+  ExtUtils::MakeMaker: '0'
+configure_requires:
+  ExtUtils::MakeMaker: '0'
+dynamic_config: 1
+generated_by: 'ExtUtils::MakeMaker version 7.76, CPAN::Meta::Converter version 2.150010'
+license: unknown
 meta-spec:
-    url:     http://module-build.sourceforge.net/META-spec-v1.3.html
-    version: 1.3
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: '1.4'
+name: OLE-Storage_Lite
+no_index:
+  directory:
+    - t
+    - inc
+requires:
+  perl: '5.006'
+version: '0.22'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.020'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,14 +1,20 @@
+use 5.006;
+
+use strict;
+use warnings;
+
 use ExtUtils::MakeMaker;
 
 
 WriteMakefile(
-    ($] >= 5.005 ? (
     'AUTHOR'        => 'Kawai Takanori (kwitknr@cpan.org)',
-    'ABSTRACT'      => 'Read and write OLE storage files.', ) : () ),
+    'ABSTRACT'      => 'Read and write OLE storage files.',
     'NAME'          => 'OLE::Storage_Lite',
     'VERSION_FROM'  => 'lib/OLE/Storage_Lite.pm',
     'NEEDS_LINKING' => 0,
-    'PREREQ_PM'     => {},
+    'PREREQ_PM'     => {
+        'perl' => '5.006',
+    },
     'dist'          => {COMPRESS => 'gzip --best', SUFFIX => 'gz'},
 
 

--- a/lib/OLE/Storage_Lite.pm
+++ b/lib/OLE/Storage_Lite.pm
@@ -1,6 +1,9 @@
 # OLE::Storage_Lite
 #  by Kawai, Takanori (Hippo2000) 2000.11.4, 8, 14
 # This Program is Still ALPHA version.
+
+use 5.006;
+
 #//////////////////////////////////////////////////////////////////////////////
 # OLE::Storage_Lite::PPS Object
 #//////////////////////////////////////////////////////////////////////////////
@@ -10,9 +13,8 @@
 package OLE::Storage_Lite::PPS;
 require Exporter;
 use strict;
-use vars qw($VERSION @ISA);
-@ISA = qw(Exporter);
-$VERSION = '0.22';
+our @ISA = qw(Exporter);
+our $VERSION = '0.22';
 
 #------------------------------------------------------------------------------
 # new (OLE::Storage_Lite::PPS)
@@ -169,9 +171,8 @@ use strict;
 use IO::File;
 use IO::Handle;
 use Fcntl;
-use vars qw($VERSION @ISA);
-@ISA = qw(OLE::Storage_Lite::PPS Exporter);
-$VERSION = '0.22';
+our @ISA = qw(OLE::Storage_Lite::PPS Exporter);
+our $VERSION = '0.22';
 sub _savePpsSetPnt($$$);
 sub _savePpsSetPnt2($$$);
 #------------------------------------------------------------------------------
@@ -711,9 +712,8 @@ sub _saveBbd($$$$)
 package OLE::Storage_Lite::PPS::File;
 require Exporter;
 use strict;
-use vars qw($VERSION @ISA);
-@ISA = qw(OLE::Storage_Lite::PPS Exporter);
-$VERSION = '0.22';
+our @ISA = qw(OLE::Storage_Lite::PPS Exporter);
+our $VERSION = '0.22';
 #------------------------------------------------------------------------------
 # new (OLE::Storage_Lite::PPS::File)
 #------------------------------------------------------------------------------
@@ -799,9 +799,8 @@ sub append ($$) {
 package OLE::Storage_Lite::PPS::Dir;
 require Exporter;
 use strict;
-use vars qw($VERSION @ISA);
-@ISA = qw(OLE::Storage_Lite::PPS Exporter);
-$VERSION = '0.22';
+our @ISA = qw(OLE::Storage_Lite::PPS Exporter);
+our $VERSION = '0.22';
 sub new ($$;$$$) {
     my($sClass, $sName, $raTime1st, $raTime2nd, $raChild) = @_;
     OLE::Storage_Lite::PPS::_new(
@@ -831,9 +830,9 @@ use IO::File;
 use List::Util qw(first);
 use Time::Local 'timegm';
 
-use vars qw($VERSION @ISA @EXPORT);
-@ISA = qw(Exporter);
-$VERSION = '0.22';
+our @ISA = qw(Exporter);
+our $VERSION = '0.22';
+our @EXPORT = ();
 sub _getPpsSearch($$$$$;$);
 sub _getPpsTree($$$;$);
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under v5.6+.

Require Perl v5.6 for this but realistically every user should be on this 25 year old version or newer by now.

https://fast2-matrix.cpantesters.org/?dist=OLE-Storage_Lite+0.22 shows no hits for anything older than 5.8.9 and in fact that version fails :thinking: 