### PR TITLE
Fix MSAT read error

### DIFF
--- a/lib/OLE/Storage_Lite.pm
+++ b/lib/OLE/Storage_Lite.pm
@@ -838,6 +838,7 @@ use constant {
   DataSizeSmall  => 0x1000,
   LongIntSize    => 4,
   PpsSize        => 0x80,
+  HeaderSize     => 0x200,
   # 0xFFFFFFFC : BDList, 0xFFFFFFFD : BBD,
   # 0xFFFFFFFE: End of Chain 0xFFFFFFFF : unused
   NormalBlockEnd => 0xFFFFFFFC,
@@ -1097,7 +1098,7 @@ sub _getBbdInfo($) {
   my $iBigBlkSize = $rhInfo->{_BIG_BLOCK_SIZE};
   my $iGetCnt;
   my $sWk;
-  my $i1stCnt = int(($iBigBlkSize - 0x4C) / OLE::Storage_Lite::LongIntSize());
+  my $i1stCnt = int((OLE::Storage_Lite::HeaderSize() - 0x4C) / OLE::Storage_Lite::LongIntSize());
   my $iBdlCnt = int($iBigBlkSize / OLE::Storage_Lite::LongIntSize()) - 1;
 
 #1. 1st BDlist

--- a/lib/OLE/Storage_Lite.pm
+++ b/lib/OLE/Storage_Lite.pm
@@ -334,7 +334,7 @@ sub _saveHeader($$$$$) {
 
 #0. Calculate Basic Setting
   my $iBlCnt = $rhInfo->{_BIG_BLOCK_SIZE} / OLE::Storage_Lite::LongIntSize();
-  my $i1stBdL = int(($rhInfo->{_BIG_BLOCK_SIZE} - 0x4C) / OLE::Storage_Lite::LongIntSize());
+  my $i1stBdL = int((OLE::Storage_Lite::HeaderSize() - 0x4C) / OLE::Storage_Lite::LongIntSize());
   my $i1stBdMax = $i1stBdL * $iBlCnt  - $i1stBdL;
   my $iBdExL = 0;
   my $iAll = $iBBcnt + $iPPScnt + $iSBDcnt;
@@ -396,6 +396,7 @@ sub _saveHeader($$$$$) {
         print {$FILE} (pack("V", $iAll+$i));
     }
     print {$FILE} ((pack("V", -1)) x($i1stBdL-$i)) if($i<$i1stBdL);
+    print {$FILE} "\x00" x ($rhInfo->{_BIG_BLOCK_SIZE} - OLE::Storage_Lite::HeaderSize()) if ($rhInfo->{_BIG_BLOCK_SIZE} > OLE::Storage_Lite::HeaderSize());
 }
 #------------------------------------------------------------------------------
 # _saveBigData (OLE::Storage_Lite::PPS)

--- a/lib/OLE/Storage_Lite.pm
+++ b/lib/OLE/Storage_Lite.pm
@@ -1163,23 +1163,23 @@ sub _getNthPps($$$){
     unpack("vCCVVV", substr($sWk, 0x40, 2+2+3*OLE::Storage_Lite::LongIntSize()));
   $iNmSize = ($iNmSize > 2)? $iNmSize - 2 : $iNmSize;
   my $sNm= substr($sWk, 0, $iNmSize);
-  my @raTime1st =
+  my $raTime1st =
         (($iType == OLE::Storage_Lite::PpsType_Root()) or ($iType == OLE::Storage_Lite::PpsType_Dir()))?
-            OLEDate2Local(substr($sWk, 0x64, 8)) : undef ,
-  my @raTime2nd =
+            [ OLEDate2Local(substr($sWk, 0x64, 8)) ] : undef ,
+  my $raTime2nd =
         (($iType == OLE::Storage_Lite::PpsType_Root()) or ($iType == OLE::Storage_Lite::PpsType_Dir()))?
-            OLEDate2Local(substr($sWk, 0x6C, 8)) : undef,
+            [ OLEDate2Local(substr($sWk, 0x6C, 8)) ] : undef,
   my($iStart, $iSize) = unpack("VV", substr($sWk, 0x74, 8));
   if($bData) {
       my $sData = _getData($iType, $iStart, $iSize, $rhInfo);
       return OLE::Storage_Lite::PPS->new(
         $iPos, $sNm, $iType, $lPpsPrev, $lPpsNext, $lDirPps,
-        \@raTime1st, \@raTime2nd, $iStart, $iSize, $sData, undef);
+        $raTime1st, $raTime2nd, $iStart, $iSize, $sData, undef);
   }
   else {
       return OLE::Storage_Lite::PPS->new(
         $iPos, $sNm, $iType, $lPpsPrev, $lPpsNext, $lDirPps,
-        \@raTime1st, \@raTime2nd, $iStart, $iSize, undef, undef);
+        $raTime1st, $raTime2nd, $iStart, $iSize, undef, undef);
   }
 }
 #------------------------------------------------------------------------------


### PR DESCRIPTION
The CFBF header is always 512 bytes, even if sectors (`_BIG_BLOCK_SIZE`) may be some other size.  The final 436 bytes the header stores the first 109 entries of the MSAT (`_BBD_INFO`), and other sectors store the rest.  The current code assumes that the CFBF header is *one sector*, not a fixed size.  This causes erroneous entries in the loaded MSAT.